### PR TITLE
Fix : Immediate timeout on problem start (Bug #2)

### DIFF
--- a/src/pages/createProblem/CreateProblem.tsx
+++ b/src/pages/createProblem/CreateProblem.tsx
@@ -162,6 +162,8 @@ const CreateProblem = () => {
             placeholder="Enter Avg. Solve Time (e.g., 5 mins)"
             value={formData.averageSolveTime}
             onChange={handleInputChange}
+            required      // making this field manadatory to fill
+            min = {5}     // having some base value
           />
 
           <textarea


### PR DESCRIPTION
Reasoning: The "Create Problem" form previously allowed submission without a valid solve time, defaulting to 00:00 and making problems unsolvable. This is critical as it breaks the core problem-solving workflow and blocks users from engaging with created problems.